### PR TITLE
Switch homepage to light background

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,7 +4,7 @@ description: DBA · Cloud · AWS · PostgreSQL
 url: https://ruochenwuu.github.io
 baseurl: ""
 # Minimal Mistakes skin: "default", "dark", "dirt", "air", etc.
-minimal_mistakes_skin: "dark"
+minimal_mistakes_skin: "default"
 remote_theme: "mmistakes/minimal-mistakes@4.24.0"
 
 plugins:

--- a/assets/css/custom.scss
+++ b/assets/css/custom.scss
@@ -4,3 +4,22 @@
 }
 .site-title { letter-spacing: 0.02em }
 .feature__wrapper .archive__item-excerpt { opacity: 0.9 }
+
+body {
+  background-color: #f6f7fb;
+}
+
+.page__hero--overlay::before {
+  background-color: rgba(255, 255, 255, 0.75);
+}
+
+@media (prefers-color-scheme: dark) {
+  body {
+    background-color: #0b0d12;
+    color: #f5f5f5;
+  }
+
+  .page__hero--overlay::before {
+    background-color: rgba(0, 0, 0, 0.55);
+  }
+}

--- a/index.md
+++ b/index.md
@@ -3,8 +3,8 @@ layout: splash
 permalink: /
 title: Hi, I'm Your Name
 header:
-  overlay_color: "#000"
-  overlay_filter: 0.5
+  overlay_color: "#fff"
+  overlay_filter: 0.25
   overlay_image: /assets/images/cover.jpg
 excerpt: >
   DBA & Cloud Engineer. PostgreSQL internals, high availability, and cloud cost optimization.


### PR DESCRIPTION
## Summary
- switch the Minimal Mistakes skin to the light variant so the default background is no longer black
- update the splash header overlay to use a light tint and add CSS overrides that respect the browser color scheme preference

## Testing
- bundle exec jekyll build *(fails: Could not locate Gemfile or .bundle/ directory)*

------
https://chatgpt.com/codex/tasks/task_e_68dd706aab188322a95ef8bb39d90f93